### PR TITLE
Corrige nombre de variable en saveStudentProfile.

### DIFF
--- a/js/student-profile-management.js
+++ b/js/student-profile-management.js
@@ -1776,11 +1776,14 @@ class BaseProfileManagement {
                 assignedTeachers: []
             };
 
-            console.log('🧑‍🎓 BaseProfileManagement: Datos del nuevo estudiante para el core:', studentDataForCore);
+            // Aquí estaba el error: studentDataForCore no estaba definida.
+            // La variable correcta con los datos del formulario es 'studentData'.
+            console.log('🧑‍🎓 BaseProfileManagement: Datos del nuevo estudiante para el core:', studentData);
 
             if (window.studentCore) {
                 try {
-                    const createdStudent = await window.studentCore.createStudent(studentDataForCore);
+                    // Usar la variable correcta 'studentData' aquí también.
+                    const createdStudent = await window.studentCore.createStudent(studentData);
                     if (createdStudent) {
                         console.log('✅ BaseProfileManagement: Estudiante creado/guardado a través de studentCore:', createdStudent);
                         this.showNotification(`✅ Perfil de ${nickname} guardado exitosamente (vía Core).`, 'success');


### PR DESCRIPTION
Se reemplazó la variable no definida 'studentDataForCore' por 'studentData' en el método saveStudentProfile de student-profile-management.js para resolver un SyntaxError que impedía la correcta ejecución del guardado de perfiles.