### PR TITLE
Fix: Resuelve condición de carrera en carga de estudiantes

### DIFF
--- a/js/student-management-core.js
+++ b/js/student-management-core.js
@@ -56,6 +56,7 @@ class StudentManagementCore {
             this.state.isInitialized = true;
             
             console.log('✅ Core de estudiantes inicializado');
+            document.dispatchEvent(new CustomEvent('studentCoreReady'));
             
         } catch (error) {
             console.error('❌ Error en inicialización del core:', error);


### PR DESCRIPTION
Modifica student-management-core.js para disparar un evento 'studentCoreReady' cuando esté inicializado. Actualiza student-profile-management.js para que espere este evento antes de intentar cargar los datos de los estudiantes, evitando así el warning de 'studentCore no disponible'.